### PR TITLE
optimize dos stub size to save 2 bytes (discovered by qkumba)

### DIFF
--- a/dos_unpacker/unpack_x86_16_DOS.asm
+++ b/dos_unpacker/unpack_x86_16_DOS.asm
@@ -105,15 +105,14 @@ upkr_decode_bit:
     dec     dx
     jns     upkr_load_bit
     movzx   ax, byte [bx]   ; u16 prob = upkr_probs[context_index]
+    neg     byte [bx]
     push    ax              ; save prob, tmp = prob
     cmp     dl, al          ; int bit = (upkr_state & 255) < prob ? 1 : 0; (carry = bit)
     pushf                   ; save bit flags
     jc      .bit            ; (skip if bit)
-    neg     al              ;   tmp = 256 - tmp;
+    xchg    [bx], al        ;   tmp = 256 - tmp;
 .bit:
-    mov     [bx], al        ; upkr_probs[context_index] = tmp + (256 - tmp + 8) >> 4;
-    neg     byte [bx]
-    shr     byte [bx], 4
+    shr     byte [bx], 4    ; upkr_probs[context_index] = tmp + (256 - tmp + 8) >> 4;
     adc     [bx], al
     mul     dh              ; upkr_state = tmp * (upkr_state >> 8) + (upkr_state & 255);
     mov     dh, 0

--- a/dos_unpacker/unpack_x86_16_DOS_no_relocation.asm
+++ b/dos_unpacker/unpack_x86_16_DOS_no_relocation.asm
@@ -95,16 +95,15 @@ upkr_decode_bit:
     inc     dx
     dec     dx              ; inc dx, dec dx is used to test the top (sign) bit of dx
     jns     upkr_load_bit
-    movzx   ax, byte [bx]   ; int prob = upkr_probs[context_index]
-    push    ax              ; save prob
+    movzx   ax, byte [bx]   ; u16 prob = upkr_probs[context_index]
+    neg     byte [bx]
+    push    ax              ; save prob, tmp = prob
     cmp     dl, al          ; int bit = (upkr_state & 255) < prob ? 1 : 0; (carry = bit)
     pushf                   ; save bit flags
     jc      .bit            ; (skip if bit)
-    neg     al              ;   tmp = 256 - tmp;
+    xchg    [bx], al        ;   tmp = 256 - tmp;
 .bit:
-    mov     [bx], al        ; tmp_new = tmp + (256 - tmp + 8) >> 4;
-    neg     byte [bx]
-    shr     byte [bx], 4
+    shr     byte [bx], 4    ; upkr_probs[context_index] = tmp + (256 - tmp + 8) >> 4;
     adc     [bx], al
     mul     dh              ; upkr_state = tmp * (upkr_state >> 8) + (upkr_state & 255);
     mov     dh, 0

--- a/dos_unpacker/unpack_x86_16_DOS_no_repeated_offset.asm
+++ b/dos_unpacker/unpack_x86_16_DOS_no_repeated_offset.asm
@@ -98,16 +98,15 @@ upkr_decode_bit:
     inc     dx
     dec     dx              ; or whatever other test for the top bit there is
     jns     upkr_load_bit
-    movzx   ax, byte [bx]   ; int prob = upkr_probs[context_index]
-    push    ax              ; save prob
+    movzx   ax, byte [bx]   ; u16 prob = upkr_probs[context_index]
+    neg     byte [bx]
+    push    ax              ; save prob, tmp = prob
     cmp     dl, al          ; int bit = (upkr_state & 255) < prob ? 1 : 0; (carry = bit)
     pushf                   ; save bit flags
     jc      .bit            ; (skip if bit)
-    neg     al              ;   tmp = 256 - tmp;
+    xchg    [bx], al        ;   tmp = 256 - tmp;
 .bit:
-    mov     [bx], al        ; tmp += (256 - tmp + 8) >> 4;
-    neg     byte [bx]
-    shr     byte [bx],4
+    shr     byte [bx], 4    ; upkr_probs[context_index] = tmp + (256 - tmp + 8) >> 4;
     adc     [bx], al        ; upkr_probs[context_index] = tmp;
     mul     dh              ; upkr_state = tmp * (upkr_state >> 8) + (upkr_state & 255);
     mov     dh, 0


### PR DESCRIPTION
This implements qkumba's 2 byte savings to the DOS unpacker stubs. Consider merging with a rebase, as the fix should be already pointing to the head of the master branch, so rebasing should be perfectly fine.